### PR TITLE
Fix GitHub URLs and add missing docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ mkdir mt5-docker && cd mt5-docker
 
 2. Download required files:
 ```bash
-wget https://github.com/jefrnc/mt5-docker-api/docker/docker-compose.yml
-wget https://github.com/jefrnc/mt5-docker-api/.env.example
+wget https://raw.githubusercontent.com/jefrnc/mt5-docker-api/main/docker-compose.yml
+wget https://raw.githubusercontent.com/jefrnc/mt5-docker-api/main/.env.example
 ```
 
 3. Configure environment:
@@ -175,12 +175,12 @@ Access MetaEditor through the MT5 interface for development.
 1. Clone the repository:
 ```bash
 git clone https://github.com/jefrnc/mt5-docker-api
-cd MetaTrader5-Docker-Image
+cd mt5-docker-api
 ```
 
 2. Build the image:
 ```bash
-docker build -f docker/Dockerfile -t metatrader5_vnc:latest .
+docker build -t mt5-docker-api:latest .
 ```
 
 ## System Requirements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  mt5-docker-api:
+    image: jsfrnc/mt5-docker-api:latest
+    container_name: mt5-docker-api
+    restart: unless-stopped
+    ports:
+      - "3000:3000"  # VNC Web Access
+      - "8000:8000"  # REST API
+      - "8001:8001"  # Python MT5 API
+    volumes:
+      - mt5_data:/root/.wine/drive_c/Program Files/MetaTrader 5
+      - ./logs:/app/logs
+    environment:
+      - MT5_LOGIN=${MT5_LOGIN}
+      - MT5_PASSWORD=${MT5_PASSWORD}
+      - MT5_SERVER=${MT5_SERVER}
+      - API_KEY=${API_KEY:-your-secure-api-key}
+      - VNC_PASSWORD=${VNC_PASSWORD:-vnc123}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - mt5-network
+
+volumes:
+  mt5_data:
+    driver: local
+
+networks:
+  mt5-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Fixed incorrect wget URLs in README that were returning 404 errors
- Added missing docker-compose.yml file to repository root
- Corrected build instructions with proper paths

## Problem
Users reported in issue #19 that the wget commands in the README were failing with 404 errors because:
1. The URLs pointed to `/docker/docker-compose.yml` which doesn't exist
2. The docker-compose.yml file was missing from the repository

## Solution
- Changed URLs to use `raw.githubusercontent.com` for direct file access
- Created docker-compose.yml with proper configuration
- Fixed incorrect directory names in build instructions
- Removed reference to non-existent `docker/Dockerfile` path

## Test plan
- [x] Verified new wget URLs will work once merged
- [x] Checked docker-compose.yml syntax
- [x] Confirmed all paths in README now point to existing files

Fixes #19