### PR TITLE
Fix GitHub Actions release workflow permissions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,61 @@
+name: Auto Release on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release ${{ steps.get_version.outputs.VERSION }}
+          body: |
+            ## 🚀 Release ${{ steps.get_version.outputs.VERSION }}
+            
+            ### Docker Image
+            
+            Pull the latest version:
+            ```bash
+            docker pull jsfrnc/mt5-docker-api:${{ steps.get_version.outputs.VERSION }}
+            docker pull jsfrnc/mt5-docker-api:latest
+            ```
+            
+            ### Quick Start
+            
+            ```bash
+            mkdir mt5-docker && cd mt5-docker
+            wget https://raw.githubusercontent.com/jefrnc/mt5-docker-api/main/docker-compose.yml
+            wget https://raw.githubusercontent.com/jefrnc/mt5-docker-api/main/.env.example
+            cp .env.example .env
+            docker-compose up -d
+            ```
+            
+            ### Access Points
+            - Web VNC: http://localhost:3000
+            - REST API: http://localhost:8000/docs
+            - MT5 Python: localhost:8001
+            
+            ### Documentation
+            - [Full Documentation](https://github.com/jefrnc/mt5-docker-api#readme)
+            - [Docker Hub](https://hub.docker.com/r/jsfrnc/mt5-docker-api)
+            
+            ### What's Changed
+            See [full changelog](https://github.com/jefrnc/mt5-docker-api/compare/v1.0.1...v${{ steps.get_version.outputs.VERSION }})
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,14 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,12 +45,11 @@ jobs:
           sleep 30
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ inputs.version }}
-          release_name: v${{ inputs.version }}
+          name: v${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             ## 🚀 Release v${{ inputs.version }}
             


### PR DESCRIPTION
## Summary
Fixes the 'Resource not accessible by integration' error in the release workflow.

## Problem
The release workflow was failing with permissions error when trying to create releases.

## Solution
1. Added explicit `contents: write` permissions to the workflow
2. Replaced deprecated `actions/create-release@v1` with `softprops/action-gh-release@v1`
3. Created new `auto-release.yml` workflow that automatically creates releases when tags are pushed

## Changes
- Updated  with proper permissions
- Added  for automatic releases on tag push
- Using modern GitHub Actions that work with current permission model

## Testing
After merging, the release workflow will:
- Work with manual dispatch 
- Automatically create releases when tags are pushed
- Properly set permissions for creating releases

This fixes the failed workflow run: https://github.com/jefrnc/mt5-docker-api/actions/runs/17472308940