### PR TITLE
Update README with Docker Hub image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 
 A containerized solution for running MetaTrader5 trading platform with web-based VNC access and Python API support.
 
+## 🐳 Docker Hub
+
+The official image is available on Docker Hub:
+
+**Repository:** [jsfrnc/mt5-docker-api](https://hub.docker.com/r/jsfrnc/mt5-docker-api)
+
+```bash
+docker pull jsfrnc/mt5-docker-api:latest
+```
+
 ## Overview
 
 This Docker image allows you to run MetaTrader5 on any system that supports Docker, providing:
@@ -27,7 +37,30 @@ This Docker image allows you to run MetaTrader5 on any system that supports Dock
 
 ## Quick Start
 
-### Using Docker Compose (Recommended)
+### Option 1: Using Docker Hub Image (Easiest)
+
+Pull and run the latest image from Docker Hub:
+
+```bash
+# Pull the latest image
+docker pull jsfrnc/mt5-docker-api:latest
+
+# Run the container
+docker run -d \
+  --name mt5-docker \
+  -p 3000:3000 \
+  -p 8000:8000 \
+  -p 8001:8001 \
+  -e VNC_PASSWORD=yourpassword \
+  -v mt5_data:/root/.wine/drive_c/Program\ Files/MetaTrader\ 5 \
+  jsfrnc/mt5-docker-api:latest
+```
+
+Available tags:
+- `jsfrnc/mt5-docker-api:latest` - Latest stable version
+- `jsfrnc/mt5-docker-api:v1.0.2` - Specific version
+
+### Option 2: Using Docker Compose (Recommended for Production)
 
 1. Create a project directory:
 ```bash
@@ -51,6 +84,8 @@ nano .env  # Edit with your settings
 docker compose up -d
 ```
 
+The image `jsfrnc/mt5-docker-api:latest` will be automatically pulled from Docker Hub.
+
 5. Access MetaTrader5:
    - Open your browser and navigate to `http://localhost:3000`
    - Login with the credentials you set in `.env`
@@ -66,7 +101,7 @@ docker run -d \
   -v mt5_config:/config \
   -e CUSTOM_USER=trader \
   -e PASSWORD=your_secure_password \
-  metatrader5_vnc:latest
+  jsfrnc/mt5-docker-api:latest
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary
Updated the README to prominently feature the Docker Hub image that is now available.

## Changes
- ✨ Added Docker Hub section at the top of README with repository link
- 📝 Added "Option 1: Using Docker Hub Image" as the easiest installation method
- 🔄 Updated all image references from old names to `jsfrnc/mt5-docker-api`
- 🏷️ Added available tags information (latest, v1.0.2)
- 📋 Clarified that docker-compose automatically pulls from Docker Hub
- 🐛 Fixed outdated image name references

## Impact
Users can now easily find and use the official Docker Hub image without needing to build locally.

## Docker Hub
The image is available at: https://hub.docker.com/r/jsfrnc/mt5-docker-api

Pull with:
```bash
docker pull jsfrnc/mt5-docker-api:latest
```