### PR TITLE
Fix: Remove duplicate release creation from Docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -223,34 +223,5 @@ jobs:
           path: vulnerability-report.txt
           retention-days: 30
 
-  create-release:
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          body: |
-            ## Docker Image
-            
-            ```bash
-            docker pull ${{ env.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            ```
-            
-            ## What's Changed
-            
-            See [full changelog](https://github.com/${{ github.repository }}/compare/previous...${{ github.ref_name }})
-            
-            ## Docker Hub
-            
-            View on Docker Hub: https://hub.docker.com/r/${{ env.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
-          draft: false
-          prerelease: false
+  # Release creation is handled by auto-release.yml workflow
+  # This job has been removed to prevent duplicate release attempts


### PR DESCRIPTION
## Summary
Removes the duplicate release creation job from the Docker workflow that was causing build failures.

## Problem
The Docker workflow was failing with "Resource not accessible by integration" error when tags were pushed because it was trying to create a release that already existed (created by auto-release.yml).

## Solution
- Removed the `create-release` job from docker-publish.yml
- Added comment explaining that releases are handled by auto-release.yml

## Impact
- Docker builds will now complete successfully when tags are pushed
- No more duplicate release attempts
- Cleaner workflow separation of concerns

## Testing
After merging, the next tag push will:
1. Trigger auto-release.yml to create the GitHub release
2. Trigger docker-publish.yml to build and push the Docker image
3. Both workflows will complete without errors

Fixes the failed workflow: https://github.com/jefrnc/mt5-docker-api/actions/runs/17476326311