### PR TITLE
chore(deps): Update remaining dependencies (closes #43, #50, #51)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm
+FROM python:3.14-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 # Testing
 pytest==8.4.*
 pytest-cov==7.0.*
-pytest-asyncio==1.1.*
+pytest-asyncio==1.2.*
 httpx==0.28.*  # For FastAPI testing
 
 # Code quality

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests==2.32.*
 urllib3==2.5.*
 
 # API dependencies
-fastapi==0.116.*
+fastapi==0.120.*
 uvicorn[standard]==0.35.*
 websockets==15.0.1
 


### PR DESCRIPTION
## Summary

Applies the 3 remaining dependabot updates that had merge conflicts:

- **pytest-asyncio** 1.1 → 1.2 (closes #43)
- **fastapi** 0.116 → 0.120 (closes #51)
- **Python** 3.13 → 3.14 (closes #50)

## Test plan

- [ ] CI pipeline passes (tests + docker build)