### PR TITLE
fix(ci): Update trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -114,7 +114,7 @@ jobs:
           docker build -t local-scan:latest .
 
       - name: Run Trivy vulnerability scanner on local image
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: 'local-scan:latest'
           format: 'sarif'


### PR DESCRIPTION
## Summary

- The `aquasecurity/trivy-action@0.33.1` tag was removed, breaking the `security-scan` job
- Updated to `v0.35.0` (latest release)

## Test plan

- [ ] security-scan job passes in CI